### PR TITLE
hashchange event updates position for hashenabled carousels only

### DIFF
--- a/src/js/owl.hash.js
+++ b/src/js/owl.hash.js
@@ -79,6 +79,11 @@
 
 		// register event listener for hash navigation
 		$(window).on('hashchange.owl.navigation', $.proxy(function(e) {
+			// check if the current owlinstance has hash navigation enabled
+			if( this._core.settings.startPosition !== 'URLHash' ) {
+				return;
+			}
+
 			var hash = window.location.hash.substring(1),
 				items = this._core.$stage.children(),
 				position = this._hashes[hash] && items.index(this._hashes[hash]);


### PR DESCRIPTION
because the hashchange.owl.navigation is bound to the window object it triggers on hashchange events for all carousels. When using multiple carousels on a page, this can be a problem when one uses hash navigation and the other one doesn't.

The latter gets it's position reset: position will evaluate to undefined because no hashes are set.

I've added code that checks if the current plugin supports hash navigation. If it doesn't, nothing happens.