### PR TITLE
Fix missing last image when using stagePadding option with lazyLoad

### DIFF
--- a/src/js/owl.lazyload.js
+++ b/src/js/owl.lazyload.js
@@ -44,7 +44,7 @@
 
 				if ((e.property && e.property.name == 'position') || e.type == 'initialized') {
 					var settings = this._core.settings,
-						n = (settings.center && Math.ceil(settings.items / 2) || settings.items),
+						n = (settings.center && Math.ceil(settings.items / 2)  || (settings.stagePadding > 0 && settings.items + 1) || settings.items),
 						i = ((settings.center && n * -1) || 0),
 						position = ((e.property && e.property.value) || this._core.current()) + i,
 						clones = this._core.clones().length,


### PR DESCRIPTION
Fix using stagePadding with lazyLoad, last image on right which is not showing complete is now loading.
